### PR TITLE
Rename `andThen` to `map`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ You can either delve into the documentation (highly recommended) or check out so
   - [`D.record`](#drecord)
   - [`D.keyValuePairs`](#dkeyvaluepairs)
   - [`D.object`](#dobject)
-- [_Decoder_`.andThen` & chaining](#decoderandthen--chaining)
+- [_Decoder_`.map` & chaining](#decoderandthen--chaining)
 
 ### Methods
 
@@ -320,12 +320,12 @@ interface Person {
 }
 ```
 
-### _Decoder_`.andThen` & chaining
+### _Decoder_`.map` & chaining
 
 If the built-in types in JSON aren't enough for you, you can extend the provided decoders. Let's say you want to decode a `Date` from an ISO string.
 
 ```ts
-const dateDecoder = D.string.andThen(date => new Date(date))
+const dateDecoder = D.string.map(date => new Date(date))
 // You can now use it with
 // dateDecoder.decode(…)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export interface Decoder<D> {
   readonly forceDecode: Decode<D>['forceDecode']
   readonly decode: (data: unknown) => ReturnType<Decode<D>['forceDecode']> | null
   readonly is: (data: unknown) => data is D
-  readonly andThen: <T>(transformer: (data: D) => T) => Decoder<T>
+  readonly map: <T>(transformer: (data: D) => T) => Decoder<T>
 }
 
 export type Output<T extends Decoder<any>> = ReturnType<T['forceDecode']>
@@ -28,7 +28,7 @@ export const createDecoder = <D>(decoder: Decode<D>): Decoder<D> => ({
       return false
     }
   },
-  andThen: (transformer) => {
+  map: (transformer) => {
     return createDecoder({
       forceDecode: (data: unknown) => transformer(decoder.forceDecode(data))
     })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -215,25 +215,25 @@ test('Decoder.decode returns null when the decoder fails', () => {
   expect(D.array(D.string).decode('test')).toStrictEqual(null)
 })
 
-// andThen
-test('Decoder.andThen changes the type after parsed', () => {
-  shouldBe(D.number.andThen($ => $.toString()), 5, '5')
+// map
+test('Decoder.map changes the type after parsed', () => {
+  shouldBe(D.number.map($ => $.toString()), 5, '5')
   const objectDecoder = D.object({
     required: { a: D.number },
     optional: { b: D.number }
-  }).andThen($ => ({
+  }).map($ => ({
     a: $.a.toString(),
     b: $.b?.toString()
   }))
   shouldBe(objectDecoder, { a: 5, b: 10 }, { a: '5', b: '10' })
   shouldBe(objectDecoder, { a: 5 }, { a: '5', b: undefined })
 })
-test('Decoder.andThen fails when the transformer fails', () => {
-  shouldFail(D.unknown.andThen(_ => { throw new D.DecoderError() }), '')
+test('Decoder.map fails when the transformer fails', () => {
+  shouldFail(D.unknown.map(_ => { throw new D.DecoderError() }), '')
 })
-test('Decoder.andThen fails when the decoder fails', () => {
-  shouldFail(D.number.andThen(Number.prototype.toString), 'test')
-  shouldFail(D.number.andThen($ => $.toString()), 'test')
+test('Decoder.map fails when the decoder fails', () => {
+  shouldFail(D.number.map(Number.prototype.toString), 'test')
+  shouldFail(D.number.map($ => $.toString()), 'test')
 })
 
 // is


### PR DESCRIPTION
`andThen` would match Elm's `andThen` a.k.a. `flatMap` or `bind` if the transform returned a Decoder, since it just maps the value, it should be called `map`.