### PR TITLE
Add regex decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,8 @@ decoder.decode('not in there') // null
 
 #### `D.regex`
 
-`D.regex` checks if a given regular expression matches the data.
-(This is particularly useful when you want to transform the data afterwards. See [`andThen`](#decoderandthen--chaining))
+`D.regex` checks if a given regular expression matches the data. (This is particularly useful when you want to transform the data afterwards. See [`andThen`](#decoderandthen--chaining))
+
 ```ts
 const decoder = D.regex(/^\d+$/)
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You can either delve into the documentation (highly recommended) or check out so
   - [`D.boolean`](#dboolean)
   - [`D.literal`](#dliteral)
   - [`D.literalUnion`](#dliteralunion)
+  - [`D.regex`](#dregex)
 - [Combinators](#combinators)
   - [`D.oneOf`](#doneof)
   - [`D.tuple`](#dtuple)
@@ -222,6 +223,24 @@ decoder.decode('data') // 'data'
 decoder.decode('error') // 'error'
 
 decoder.decode('not in there') // null
+```
+
+#### `D.regex`
+
+`D.regex` checks if a given regular expression matches the data.
+(This is particularly useful when you want to transform the data afterwards. See [`andThen`](#decoderandthen--chaining))
+```ts
+const decoder = D.regex(/^\d+$/)
+
+decoder.decode('138') // '138'
+
+decoder.decode('Not nice') // null
+```
+
+With transformation afterwards:
+
+```ts
+decoder.decode('138').andThen(Number) // 138
 ```
 
 ### Combinators

--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,17 @@ export const oneOf = <D extends readonly any[]>(
 export const literalUnion = <D extends ReadonlyArray<string | number | boolean>>(...decoders: D): Decoder<D[number]> =>
   oneOf(...decoders.map(literal))
 
+export const regex = <D extends string>(regex: RegExp): Decoder<D> =>
+  createDecoder({
+    forceDecode: (data) => {
+      checkDefined(data)
+      if (!regex.test(data as D)) {
+        throw new DecoderError(`Data '${data as D}' does not satisfy the regex '${String(regex)}'.`)
+      }
+      return data as D
+    }
+  })
+
 //
 // Arrays
 //

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -118,6 +118,17 @@ test('D.literalUnion fails when given null or undefined', () => {
   shouldFail(D.literalUnion('a', 5), undefined)
 })
 
+// Regex
+test('D.regex succeeds when regex is satisfied', () => {
+  shouldBe(D.regex(/^[a-z]+$/), 'test', 'test')
+})
+
+test('D.regex fails when regex is not satisfied', () => {
+  shouldFail(D.regex(/^[a-z]+$/), 'TEST!')
+  shouldFail(D.regex(/^[a-z]+$/), null)
+  shouldFail(D.regex(/^[a-z]+$/), undefined)
+})
+
 // Array
 test('D.array succeeds when given an array of the correct type', () => {
   shouldBe(D.array(D.unknown), [], [])


### PR DESCRIPTION
Hi @michaljanocko ! I really like `schemawax` 🚀
But I was missing a `regex` decoder. It can be created in userland but I figured it's a pretty common use case that could be offered by this library.

✌️ 