### PR TITLE
Add iterable as more-lax version of array

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can either delve into the documentation (highly recommended) or check out so
   - [`D.oneOf`](#doneof)
   - [`D.tuple`](#dtuple)
   - [`D.array`](#darray)
+  - [`D.iterable`](#diterable)
   - [`D.record`](#drecord)
   - [`D.keyValuePairs`](#dkeyvaluepairs)
   - [`D.object`](#dobject)
@@ -291,6 +292,14 @@ The array decoder takes another decoder with which it tries to decode a whole JS
 D.array(D.number).decode([1, 2, 3]) // [1, 2, 3]
 
 D.array(D.number).decode([1, 2, 'not a number']) // null
+```
+
+#### `D.iterable`
+
+The iterable decoder is like the array decoder but accepts any iterable type, instead of just arrays:
+
+```
+D.iterable(D.number).decode(new Set([1, 2, 3])) // [1, 2, 3]
 ```
 
 #### `D.record`

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -142,10 +142,25 @@ test('D.array fails when given something that is not an array', () => {
   shouldFail(D.array(D.unknown), {})
   shouldFail(D.array(D.unknown), 5)
   shouldFail(D.array(D.unknown), 'test')
+  shouldFail(D.array(D.unknown), new Set())
 })
 test('D.array fails when given null or undefined', () => {
   shouldFail(D.array(D.unknown), undefined)
   shouldFail(D.array(D.unknown), null)
+})
+
+// Iterable
+test('D.iterable succeeds when given a set', () => {
+  shouldBe(D.iterable(D.unknown), new Set(), [])
+  shouldBe(D.iterable(D.number), new Set([1, 2, 3]), [1, 2, 3])
+})
+test('D.iterable fails when given a set of wrong types', () => {
+  shouldFail(D.iterable(D.number), new Set(['test', 'test']))
+  shouldFail(D.iterable(D.number), new Set([1, 2, 3, '']))
+})
+test('D.iterable fails when given null or undefined', () => {
+  shouldFail(D.iterable(D.unknown), undefined)
+  shouldFail(D.iterable(D.unknown), null)
 })
 
 // Tuple


### PR DESCRIPTION
Right now, `D.array` only accepts array types, which can be overly restrictive, but is often desired. This adds the `D.iterable` combinator which still returns an array, but accepts any type that implements the [iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol).