### PR TITLE
Avoid using conditional types to improve type checking

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,8 +241,8 @@ export const keyValuePairs = <D>(decoder: Decoder<D>): Decoder<Array<[string, D]
 //
 
 export type DecoderRecord = Record<PropertyKey, Decoder<any>>
-type OmitEmptyPartial<T extends DecoderRecord> = T extends infer U & Partial<{ [x: string]: any }> ? U : never
-type ObjectType<D extends DecoderRecord> = D extends { [K in keyof infer U]: Decoder<(infer U)[K]> } ? U : never
+type OmitEmptyPartial<D extends DecoderRecord> = { [K in keyof D]: Exclude<D[K], undefined> }
+type ObjectType<D extends DecoderRecord> = { [K in keyof D]: Output<D[K]> }
 
 const required = <D extends DecoderRecord>(
   struct: D


### PR DESCRIPTION
This modifies the `ObjectType` and `OmitEmptyPartial` types to directly compute the result instead of relying on type inference. This helps a bit when trying to create decoders with generic type inputs, since TS sometimes has trouble inferring types with nested generics.

Fair warning: I have absolutely no idea what `OmitEmptyPartial` is supposed to do, but the result of what I made does seem to pass all the tests, which means either there's a test not covering this or it's not particularly useful.