### PR TITLE
Add never decoder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,15 @@ export const succeed = <T> (value: T): Decoder<T> => createDecoder({
   forceDecode: () => value
 })
 
+/**
+ * A decoder that always fails. Useful for overriding existing decoders.
+ */
+export const never: Decoder<never> = createDecoder({
+  forceDecode: () => {
+    throw new DecoderError('This field must never be present')
+  }
+})
+
 const primitiveDecoder = <D>(
   dataType: string,
   condition: (data: unknown) => data is D


### PR DESCRIPTION
I've found this useful in a few situations, namely:

* If I have code that wraps a decoder in an array, you can still guarantee `[]` by passing in `D.never` without having to unwrap the decoder and pass in `D.tuple()`.
* When combining decoders, if you want to explicitly guarantee that a field is not present, you can use this.