### PR TITLE
Export forceDecodeWithPath function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ export class DecoderError extends SyntaxError {
   }
 }
 
-const forceDecodeWithPath = <T>(decoder: Decoder<T>, data: unknown, pathPart: string): T => {
+export const forceDecodeWithPath = <T>(decoder: Decoder<T>, data: unknown, pathPart: string): T => {
   try {
     return decoder.forceDecode(data)
   } catch (e) {


### PR DESCRIPTION
## Summary

This PR exposes the method introduced by @francescortiz in [Schemawax PR #19](https://github.com/michaljanocko/schemawax/pull/19) so it can be consumed by library users.

## Motivation

The functionality added in the referenced PR is useful beyond internal usage, but it is currently not exported as part of the public API. As a result, consumers of the library cannot take advantage of it without re-implementing similar logic.

## Changes

Exported the method defined in [PR #19](https://github.com/michaljanocko/schemawax/pull/19)

## Impact

- No breaking changes
- Enables users to directly use the method without workarounds
- Improves developer experience and avoids duplication of logic

## Notes
 This PR does not modify the original implementation, only its visibility/export